### PR TITLE
Issue/14: make `piminflux_reader` plug-in compatible with ParaView 5.12.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file. Detailed in
 
 ## [0.4.1] - TBD
 
-### Net features
+### New features
 
 * More efficient calculation of tracking-related statistics.
 * Add option to pool DCR values for all relocalized iterations weighted by their photon count.
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file. Detailed in
 
 ### Bug fixes
 
+* Make `pyminflux_reader.py` plug-in compatible with ParaView 5.12.
 * Only calculate and export tracking statistics for tracking datasets.
 * Do not allow plotting average localization of tracking datasets.
 

--- a/paraview_plugins/pyminflux_reader.py
+++ b/paraview_plugins/pyminflux_reader.py
@@ -176,7 +176,7 @@ class pyMINFLUXReader(VTKPythonAlgorithmBase):
         layout = CreateLayout("pyMINFLUX")
 
         # Create a render view
-        render_view = CreateView("RenderView", "Localizations")
+        render_view = CreateView("RenderView")
         render_view.AxesGrid = "GridAxes3DActor"
         render_view.Background = [0.0, 0.0, 0.0]
         render_view.UseColorPaletteForBackground = 0


### PR DESCRIPTION
In ParaView 5.11, `paraview.simple.CreateView()` could take a second, optional argument; ParaView 5.12 drops it. The plug-in now uses the 5.12 API, that is backward-compatible with ParaView 5.11. This fixes issue/14.
