### PR TITLE
typo_fix dev-requirements.txt

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,6 +3,6 @@ pdoc3==0.10.0
 pre-commit==3.8.0
 pytest==8.3.2
 pytest-cov==4.1.0
-nuitka==2.4.5
-zstandard==0.22.0
+nuitka==2.4.11
+zstandard==0.23.0
 ruff==0.4.10

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -3,6 +3,6 @@ pdoc3==0.10.0
 pre-commit==3.8.0
 pytest==8.3.2
 pytest-cov==4.1.0
-nuitka=2.4.5
-zstandard=0.22.0
-ruff=0.4.10
+nuitka==2.4.5
+zstandard==0.22.0
+ruff==0.4.10


### PR DESCRIPTION
Fixed three small typos in the dev-requirements.txt that lead to a raised error during `pip install -r dev-requirements.txt`.